### PR TITLE
Handle dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,8 @@ Example usage from PHP (e.g. for an update hook):
 
 ```php
 // Import configuration from all projects that contain a 'cm_config_tools' key.
-\Drupal::service('cm_config_tools')->importAll();
+\Drupal::service('cm_config_tools')->import();
 
-// Just import from mymodule
-\Drupal::service('cm_config_tools')->importExtension('mymodule');
-
-// Just import from two specific modules.
-\Drupal::service('cm_config_tools')->importExtension(['mymodule', 'othermodule']);
+// Export configuration.
+\Drupal::service('cm_config_tools')->export();
 ```

--- a/cm_config_tools.services.yml
+++ b/cm_config_tools.services.yml
@@ -1,7 +1,7 @@
 services:
   cm_config_tools:
     class: Drupal\cm_config_tools\ExtensionConfigHandler
-    arguments: ['@config.storage', '@info_parser', '@module_handler', '@module_installer', '@theme_handler', '@config.manager', '@config_update.config_diff', '@lock.persistent', '@config.typed', '@event_dispatcher', '@string_translation']
+    arguments: ['@config.storage', '@info_parser', '@module_handler', '@module_installer', '@theme_handler', '@config.manager', '@config_update.config_diff', '@lock.persistent', '@state', '@config.typed', '@event_dispatcher', '@string_translation']
   cm_config_tools.config_installer:
     class:  Drupal\cm_config_tools\ConfigInstaller
     arguments: ['@cm_config_tools.config_installer.inner', '@cm_config_tools', '@config.factory', '@config.storage', '@config.manager']

--- a/drush/cm_config_tools.drush.inc
+++ b/drush/cm_config_tools.drush.inc
@@ -19,12 +19,11 @@ function cm_config_tools_drush_command() {
   $description = '';
   $description .= "Write back configuration to module's config/install directory." . "\n";
   $description .= "List which configuration settings you want to export in the" . "\n";
-  $description .= "module's info file by listing them under 'config_devel', as shown below:"  . "\n";
+  $description .= "modules info file by listing them under 'cm_config_tools', as shown below:"  . "\n";
   $description .= "\n";
-  $description .= "config_devel:"  . "\n";
-  $description .= "  - entity.view_display.node.article.default"  . "\n";
-  $description .= "  - entity.view_display.node.article.teaser"  . "\n";
-  $description .= "  - field.instance.node.article.body"  . "\n";
+  $description .= "cm_config_tools:"  . "\n";
+  $description .= "  managed:"  . "\n";
+  $description .= "    - field.field.node.page.field_image"  . "\n";
 
   $items['cm-config-tools-export'] = array(
     'drupal dependencies' => array('config', 'config_update'),
@@ -34,7 +33,7 @@ function cm_config_tools_drush_command() {
     ),
     'options' => array(
       'all' => array(
-        'description' => 'Without this option, any config listed as \'create_only\' is only exported when it has not previously been exported. Set this option to overwrite any such config even if it has been previously exported.',
+        'description' => 'Without this option, any config listed as \'unmanaged\' is only exported when it has not previously been exported. Set this option to overwrite any such config even if it has been previously exported.',
       ),
       'subdir' => array(
         'description' => 'Sub-directory of configuration to import. Defaults to "config/install".',
@@ -62,7 +61,7 @@ function cm_config_tools_drush_command() {
   $description .= "cm_config_tools:"  . "\n";
   $description .= "  delete:"  . "\n";
   $description .= "    - field.field.node.article.body"  . "\n";
-  $description .= "  create_only:"  . "\n";
+  $description .= "  unmanaged:"  . "\n";
   $description .= "    - image.style.full_width"  . "\n";
 
   $items['cm-config-tools-import'] = array(

--- a/drush/cm_config_tools.drush.inc
+++ b/drush/cm_config_tools.drush.inc
@@ -32,11 +32,9 @@ function cm_config_tools_drush_command() {
 
   $items['cm-config-tools-export'] = $dependencies + array(
     'description' => $description,
-    'arguments' => array(
-      'projects' => 'Module/theme machine names, separated with commas. If left blank, export to any enabled projects containing a \'cm_config_tools\' key in their .info.yml files.',
-    ),
+    'arguments' => array(),
     'options' => array(
-      'all' => array(
+      'force-unmanaged' => array(
         'description' => 'Without this option, any config listed as \'unmanaged\' is only exported when it has not previously been exported. Set this option to overwrite any such config even if it has been previously exported.',
       ),
       'subdir' => array(
@@ -44,13 +42,12 @@ function cm_config_tools_drush_command() {
         'example-value' => 'config/optional',
       ),
       'fully-normalize' => array(
-        'description' => 'Sort configuration keys when exporting, and strip any empty arrays. This ensures more reliability when comparing between source and target config but usually means unnecessary changes.',
+        'description' => 'Sort keys within configuration items when exporting, and strip any empty arrays. This ensures more reliability when comparing between source and target config but usually means unnecessary changes.',
       ),
     ),
     'required-arguments' => FALSE,
     'examples' => array(
-      'drush cm-config-tools-export' => 'Write back configuration to the specified modules from the active storage, from any projects containing a \'cm_config_tools\' key in their .info.yml files.',
-      'drush cm-config-tools-export mymodule,othermodule --fully-normalize' => 'Write back normalized (sorted and unfiltered) configuration to the specified modules, based on .info file.',
+      'drush cm-config-tools-export' => 'Write back configuration from the active storage, to any projects containing a \'cm_config_tools\' key in their .info.yml files.',
     ),
     'aliases' => array('cmce'),
   );
@@ -69,13 +66,14 @@ function cm_config_tools_drush_command() {
 
   $items['cm-config-tools-import'] = $dependencies + array(
     'description' => $description,
-    'arguments' => array(
-      'project' => 'Module/theme machine name. Separate multiple projects with commas. If left blank, import from any enabled projects containing a \'cm_config_tools\' key in their .info.yml files.',
-    ),
+    'arguments' => array(),
     'options' => array(
       'preview' => array(
         'description' => 'Format for displaying proposed changes. Recognized values: list, diff. Defaults to list. Set to 0 to disable.',
         'example-value' => 'list',
+      ),
+      'force-unmanaged' => array(
+        'description' => 'Without this option, any config listed as \'unmanaged\' is only imported when it has not previously been created. Set this option to overwrite any such config even if it has been previously created.',
       ),
       'subdir' => array(
         'description' => 'Sub-directory of configuration to import. Defaults to "config/install".',
@@ -84,11 +82,13 @@ function cm_config_tools_drush_command() {
     ),
     'required-arguments' => FALSE,
     'examples' => array(
-      'drush cm-config-tools-import' => 'Import configuration into the active storage, from any projects containing a \'cm_config_tools\' key in their .info.yml files.',
-      'drush cm-config-tools-import mymodule --preview=0' => 'Import configuration into the active storage, from the specified project, without any preview.',
+      'drush cm-config-tools-import --preview=0' => 'Import configuration into the active storage, from any projects containing a \'cm_config_tools\' key in their .info.yml files, without any preview.',
     ),
     'aliases' => array('cmci'),
   );
+
+  // @TODO Add commands to get dependencies and suggest dependants. Optionally
+  // invoke them from drush_cm_config_tools_export().
 
   return $items;
 }
@@ -96,19 +96,14 @@ function cm_config_tools_drush_command() {
 /**
  * Drush command callback.
  */
-function drush_cm_config_tools_export($extensions = NULL) {
+function drush_cm_config_tools_export() {
   $subdir = drush_get_option('subdir', InstallStorage::CONFIG_INSTALL_DIRECTORY);
-  $all = drush_get_option('all', FALSE);
+  $force_unmanaged = drush_get_option('force-unmanaged', FALSE);
   $fully_normalize = drush_get_option('fully-normalize', FALSE);
 
   /** @var \Drupal\cm_config_tools\ExtensionConfigHandler $helper */
   $helper = \Drupal::service('cm_config_tools');
-  if ($extensions) {
-    $result = $helper->exportExtension($extensions, $subdir, $all, $fully_normalize);
-  }
-  else {
-    $result = $helper->exportAll($subdir, $all, $fully_normalize);
-  }
+  $result = $helper->export($subdir, $force_unmanaged, $fully_normalize);
 
   if ($result === TRUE) {
     return drush_log(dt('Configuration successfully exported.'), LogLevel::SUCCESS);
@@ -132,18 +127,14 @@ function drush_cm_config_tools_export($extensions = NULL) {
 /**
  * Drush command callback.
  */
-function drush_cm_config_tools_import($extensions = NULL) {
+function drush_cm_config_tools_import() {
   /** @var \Drupal\cm_config_tools\ExtensionConfigHandler $helper */
   $helper = \Drupal::service('cm_config_tools');
-  if ($extensions) {
-    $extension_dirs = $helper->getExtensionDirectories($extensions);
-  }
-  else {
-    $extension_dirs = $helper->getAllExtensionDirectories();
-  }
-
   $subdir = drush_get_option('subdir', InstallStorage::CONFIG_INSTALL_DIRECTORY);
-  if ($extension_dirs && ($storage_comparer = $helper->getStorageComparer($extension_dirs, $subdir))) {
+  $force_unmanaged = drush_get_option('force-unmanaged', FALSE);
+  $extension_dirs = $helper->getExtensionDirectories();
+
+  if ($extension_dirs && ($storage_comparer = $helper->getStorageComparer($extension_dirs, $subdir, $force_unmanaged))) {
     if ($preview = drush_get_option('preview', 'table')) {
       if ($preview == 'diff') {
         drush_cm_config_tools_preview_diff($storage_comparer, $extension_dirs, $subdir);

--- a/drush/cm_config_tools.drush.inc
+++ b/drush/cm_config_tools.drush.inc
@@ -19,7 +19,7 @@ function cm_config_tools_drush_command() {
   $description = '';
   $description .= "Write back configuration to module's config/install directory." . "\n";
   $description .= "List which configuration settings you want to export in the" . "\n";
-  $description .= "modules info file by listing them under 'cm_config_tools', as shown below:"  . "\n";
+  $description .= "module's info file by listing them under 'cm_config_tools', as shown below:"  . "\n";
   $description .= "\n";
   $description .= "cm_config_tools:"  . "\n";
   $description .= "  managed:"  . "\n";

--- a/drush/cm_config_tools.drush.inc
+++ b/drush/cm_config_tools.drush.inc
@@ -88,7 +88,8 @@ function cm_config_tools_drush_command() {
   );
 
   // @TODO Add commands to get dependencies and suggest dependants. Optionally
-  // invoke them from drush_cm_config_tools_export().
+  // invoke them from drush_cm_config_tools_export(). See the @TODO note in
+  // ExtensionConfigHandlerInterface::export() for options.
 
   return $items;
 }

--- a/drush/cm_config_tools.drush.inc
+++ b/drush/cm_config_tools.drush.inc
@@ -257,7 +257,7 @@ function drush_cm_config_tools_preview_table(ConfigDiffStorageComparer $storage_
   }
 
   $rows = array();
-  $rows[] = array('Provded by', 'Config', 'Operation');
+  $rows[] = array('Provided by', 'Config', 'Operation');
   foreach ($storage_comparer->getChangelist() as $change => $configs) {
     switch ($change) {
       case 'delete':

--- a/src/ConfigInstaller.php
+++ b/src/ConfigInstaller.php
@@ -112,7 +112,13 @@ class ConfigInstaller implements ConfigInstallerInterface {
     // Install profiles and extensions using cm_config_tools can have config
     // clashes. Configuration that has the same name as a module's configuration
     // will be used instead.
-    if ($this->helper->getExtensionType($name) != 'profile' && !$this->helper->getExtensionInfo($name, NULL, NULL, 'cm_config_tools', TRUE)) {
+    // @TODO Modules using cm_config_tools should not override any configuration
+    // marked as unmanaged if it already exists. Not quite sure where to do
+    // this. Install profiles are a slightly special case -- their configuration
+    // is explicitly allowed to override existing configuration, so any of their
+    // configuration that is marked as unmanaged is allowed to override the
+    // existing configuration on installation.
+    if ($this->helper->getExtensionType($name) != 'profile' && !$this->helper->getExtensionInfo($name, NULL, FALSE, TRUE)) {
       // Throw an exception if the module being installed contains configuration
       // that already exists. Additionally, can not continue installing more
       // modules because those may depend on the current module being installed.

--- a/src/ExtensionConfigHandler.php
+++ b/src/ExtensionConfigHandler.php
@@ -413,7 +413,7 @@ class ExtensionConfigHandler implements ExtensionConfigHandlerInterface {
           $recursive_iterations++;
           if ($recursion_limit && $recursive_iterations < $recursion_limit) {
             foreach ($config_dependencies['config'] as $dependency) {
-              $sub_dependencies = $this->getIndividualConfigDependencies($dependency, $recursion_limit);
+              $sub_dependencies = $this->getConfigDependencies($dependency, $recursion_limit);
 
               // Add this dependency's dependencies to the list to be returned.
               foreach ($sub_dependencies as $dependency_type => $type_dependencies) {

--- a/src/ExtensionConfigHandler.php
+++ b/src/ExtensionConfigHandler.php
@@ -352,7 +352,7 @@ class ExtensionConfigHandler implements ExtensionConfigHandlerInterface {
     return $source_storage;
   }
 
-  public function sortAndFilterOutput($dependencies) {
+  protected function sortAndFilterOutput($dependencies) {
     // Sort and filter dependency lists, and finally change to simple indexed
     // array lists. This means the output can then be directly copied for use
     // in a .info.yml file if the output format is YAML.

--- a/src/ExtensionConfigHandler.php
+++ b/src/ExtensionConfigHandler.php
@@ -470,10 +470,10 @@ class ExtensionConfigHandler implements ExtensionConfigHandlerInterface {
         $info = $this->infoParser->parse($info_filename);
 
         if ($key) {
-          return isset($info['cm_tools_config'][$key]) ? $info['cm_tools_config'][$key] : $default;
+          return isset($info['cm_config_tools'][$key]) ? $info['cm_config_tools'][$key] : $default;
         }
         else {
-          return array_key_exists('cm_tools_config', $info);
+          return array_key_exists('cm_config_tools', $info);
         }
       }
     }

--- a/src/ExtensionConfigHandler.php
+++ b/src/ExtensionConfigHandler.php
@@ -12,6 +12,7 @@ use Drupal\cm_config_tools\Exception\ExtensionConfigLockedException;
 use Drupal\config_update\ConfigDiffInterface;
 use Drupal\Core\Config\ConfigImporter;
 use Drupal\Core\Config\ConfigManagerInterface;
+use Drupal\Core\Config\Entity\ConfigDependencyManager;
 use Drupal\Core\Config\FileStorage;
 use Drupal\Core\Config\InstallStorage;
 use Drupal\Core\Config\StorageComparerInterface;
@@ -23,6 +24,7 @@ use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Extension\ModuleInstallerInterface;
 use Drupal\Core\Extension\ThemeHandlerInterface;
 use Drupal\Core\Lock\LockBackendInterface;
+use Drupal\Core\State\StateInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslationInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -91,6 +93,13 @@ class ExtensionConfigHandler implements ExtensionConfigHandlerInterface {
   protected $lock;
 
   /**
+   * The Key/Value Store to use for state.
+   *
+   * @var \Drupal\Core\State\StateInterface
+   */
+  protected $state;
+
+  /**
    * The typed config manager.
    *
    * @var \Drupal\Core\Config\TypedConfigManagerInterface
@@ -123,6 +132,8 @@ class ExtensionConfigHandler implements ExtensionConfigHandlerInterface {
    *   The config differ.
    * @param \Drupal\Core\Lock\LockBackendInterface $lock
    *   The lock backend to ensure multiple imports do not occur at the same time.
+   * @param \Drupal\Core\State\StateInterface $state
+   *   The state keyvalue store.
    * @param \Drupal\Core\Config\TypedConfigManagerInterface $typed_config
    *   The typed configuration manager.
    * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $dispatcher
@@ -130,7 +141,7 @@ class ExtensionConfigHandler implements ExtensionConfigHandlerInterface {
    * @param \Drupal\Core\StringTranslation\TranslationInterface $translation
    *   String translation service.
    */
-  public function __construct(StorageInterface $active_config_storage, InfoParserInterface $info_parser, ModuleHandlerInterface $module_handler, ModuleInstallerInterface $module_installer, ThemeHandlerInterface $theme_handler, ConfigManagerInterface $config_manager, ConfigDiffInterface $config_diff, LockBackendInterface $lock, TypedConfigManagerInterface $typed_config, EventDispatcherInterface $dispatcher, TranslationInterface $translation) {
+  public function __construct(StorageInterface $active_config_storage, InfoParserInterface $info_parser, ModuleHandlerInterface $module_handler, ModuleInstallerInterface $module_installer, ThemeHandlerInterface $theme_handler, ConfigManagerInterface $config_manager, ConfigDiffInterface $config_diff, LockBackendInterface $lock, StateInterface $state, TypedConfigManagerInterface $typed_config, EventDispatcherInterface $dispatcher, TranslationInterface $translation) {
     $this->activeConfigStorage = $active_config_storage;
     $this->infoParser = $info_parser;
     $this->moduleHandler = $module_handler;
@@ -139,6 +150,7 @@ class ExtensionConfigHandler implements ExtensionConfigHandlerInterface {
     $this->configManager = $config_manager;
     $this->configDiff = $config_diff;
     $this->lock = $lock;
+    $this->state = $state;
     $this->typedConfigManager = $typed_config;
     $this->dispatcher = $dispatcher;
     $this->stringTranslation = $translation;
@@ -147,21 +159,9 @@ class ExtensionConfigHandler implements ExtensionConfigHandlerInterface {
   /**
    * {@inheritdoc}
    */
-  public function importExtension($extension, $subdir = InstallStorage::CONFIG_INSTALL_DIRECTORY) {
-    if ($extension_dirs = $this->getExtensionDirectories($extension)) {
-      return $this->importExtensionDirectories($extension_dirs, $subdir);
-    }
-    else {
-      return FALSE;
-    }
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function importAll($subdir = InstallStorage::CONFIG_INSTALL_DIRECTORY) {
-    if ($extension_dirs = $this->getAllExtensionDirectories()) {
-      return $this->importExtensionDirectories($extension_dirs, $subdir);
+  public function import($subdir = InstallStorage::CONFIG_INSTALL_DIRECTORY, $force_unmanaged = FALSE) {
+    if ($extension_dirs = $this->getExtensionDirectories()) {
+      return $this->importExtensionDirectories($extension_dirs, $subdir, $force_unmanaged);
     }
     else {
       return FALSE;
@@ -175,13 +175,17 @@ class ExtensionConfigHandler implements ExtensionConfigHandlerInterface {
    *   Array of source directories as keys, mapped to their project names.
    * @param string $subdir
    *   The sub-directory of configuration to import.
+   * @param bool $force_unmanaged
+   *   Without this option, any config listed as 'unmanaged' is only considered
+   *   when it has not previously been created. Set this option to overwrite any
+   *   such config even if it has been previously created.
    *
    * @return bool
    *   TRUE if the operation succeeded; FALSE if the configuration changes could
    *   not be found to import.
    */
-  protected function importExtensionDirectories($source_dirs, $subdir) {
-    if ($storage_comparer = $this->getStorageComparer($source_dirs, $subdir)) {
+  protected function importExtensionDirectories($source_dirs, $subdir, $force_unmanaged) {
+    if ($storage_comparer = $this->getStorageComparer($source_dirs, $subdir, $force_unmanaged)) {
       return $this->importFromComparer($storage_comparer);
     }
     else {
@@ -230,26 +234,7 @@ class ExtensionConfigHandler implements ExtensionConfigHandlerInterface {
   /**
    * {@inheritdoc}
    */
-  public function getExtensionDirectories($extension) {
-    $source_dirs = array();
-    if (!is_array($extension)) {
-      $extension = array_map('trim', explode(',', $extension));
-    }
-    foreach ($extension as $extension_name) {
-      // Determine the type of extension we're dealing with.
-      if ($type = $this->getExtensionType($extension_name)) {
-        if ($extension_path = drupal_get_path($type, $extension_name)) {
-          $source_dirs[$extension_path] = $extension_name;
-        }
-      }
-    }
-    return $source_dirs;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function getAllExtensionDirectories() {
+  public function getExtensionDirectories() {
     $source_dirs = array();
     // Import configuration from any enabled extensions with the cm_config_tools
     // key in their .info.yml file.
@@ -269,9 +254,9 @@ class ExtensionConfigHandler implements ExtensionConfigHandlerInterface {
   /**
    * {@inheritdoc}
    */
-  public function getStorageComparer(array $source_dirs, $subdir = InstallStorage::CONFIG_INSTALL_DIRECTORY) {
+  public function getStorageComparer(array $source_dirs, $subdir = InstallStorage::CONFIG_INSTALL_DIRECTORY, $force_unmanaged = FALSE) {
     $storage_comparer = new ConfigDiffStorageComparer(
-      $this->getSourceStorageWrapper($source_dirs, $subdir),
+      $this->getSourceStorageWrapper($source_dirs, $subdir, $force_unmanaged),
       $this->activeConfigStorage,
       $this->configDiff
     );
@@ -297,17 +282,21 @@ class ExtensionConfigHandler implements ExtensionConfigHandlerInterface {
    * @param string $subdir
    *   The sub-directory of configuration to import. Defaults to
    *   "config/install".
+   * @param bool $force_unmanaged
+   *   Optional. Without this option, any config listed as 'unmanaged' is only
+   *   considered when it has not previously been created. Set this option to
+   *   overwrite any such config even if it has been previously created.
    *
    * @return StorageReplaceDataMappedWrapper
    *   The source storage, wrapped to allow replacing specific configuration.
    *
    * @throws ExtensionConfigConflictException
    */
-  protected function getSourceStorageWrapper(array $source_dirs, $subdir = InstallStorage::CONFIG_INSTALL_DIRECTORY) {
+  protected function getSourceStorageWrapper(array $source_dirs, $subdir = InstallStorage::CONFIG_INSTALL_DIRECTORY, $force_unmanaged = FALSE) {
     $source_storage = new StorageReplaceDataMappedWrapper($this->activeConfigStorage);
 
     foreach ($source_dirs as $source_dir => $extension_name) {
-      $unmanaged = $this->getExtensionInfo($extension_name, 'unmanaged', array());
+      $unmanaged = $force_unmanaged ? array() : $this->getExtensionInfo($extension_name, 'unmanaged', array());
       if (is_array($unmanaged)) {
         $unmanaged = array_flip($unmanaged);
       }
@@ -352,10 +341,20 @@ class ExtensionConfigHandler implements ExtensionConfigHandlerInterface {
     return $source_storage;
   }
 
+  /**
+   * Sort and filter dependency lists.
+   *
+   * Also changes input array to a simple indexed array list. This means the
+   * output can then be directly copied for use in an .info.yml file if the
+   * output format is YAML.
+   *
+   * @param array $dependencies
+   *   Array of config item dependencies.
+   *
+   * @return array
+   *   Sorted and filtered array of dependencies, keyed by dependency type..
+   */
   protected function sortAndFilterOutput($dependencies) {
-    // Sort and filter dependency lists, and finally change to simple indexed
-    // array lists. This means the output can then be directly copied for use
-    // in a .info.yml file if the output format is YAML.
     foreach (array_keys($dependencies) as $dependency_type) {
       if ($dependencies[$dependency_type]) {
         sort($dependencies[$dependency_type]);
@@ -373,35 +372,34 @@ class ExtensionConfigHandler implements ExtensionConfigHandlerInterface {
    */
   public function getExtensionConfigDependencies($extension, $limit = NULL) {
     $dependencies = array();
-    $listed_config = $this->getExtensionInfo($extension, 'managed');
-    foreach ($listed_config as $key) {
-      $config_dependencies = $this->getConfigDependencies($key, $limit);
-      foreach ($config_dependencies as $dependency_type => $type_dependencies) {
-        if (!isset($dependencies[$dependency_type])) {
-          $dependencies[$dependency_type] = array();
+    $listed_config = $this->getExtensionInfo($extension, 'managed', array());
+    if ($listed_config && is_array($listed_config)) {
+      foreach ($listed_config as $config_name) {
+        $config_dependencies = $this->getConfigDependencies($config_name, $limit);
+        foreach ($config_dependencies as $dependency_type => $type_dependencies) {
+          if (!isset($dependencies[$dependency_type])) {
+            $dependencies[$dependency_type] = array();
+          }
+          $dependencies[$dependency_type] += $type_dependencies;
         }
-        $dependencies[$dependency_type] += $type_dependencies;
       }
+
+      // Exclude 'core' and the specified extension from the full list.
+      unset($dependencies['module']['core']);
+      unset($dependencies['module'][$extension]);
     }
-    // Exclude 'core' and the specified extension from the full list.
-    unset($dependencies['module']['core']);
-    unset($dependencies['module'][$extension]);
     return $this->sortAndFilterOutput($dependencies);
   }
 
   /**
-   * @param $name
-   *   The config key to find the dependencies of.
-   * @param null $recursion_limit
-   *   Optionally limit the levels of recursion.
-   * @return mixed
+   * {@inheritdoc}
    */
-  public function getConfigDependencies($name, $recursion_limit = NULL) {
+  public function getConfigDependencies($config_name, $recursion_limit = NULL) {
     static $recursive_iterations = 0;
     static $checked = array();
 
-    if (!isset($checked[$name])) {
-      $config_dependencies = \Drupal::config($name)->get('dependencies');
+    if (!isset($checked[$config_name])) {
+      $config_dependencies = $this->configManager->getConfigFactory()->get($config_name)->get('dependencies');
       if ($config_dependencies && is_array($config_dependencies)) {
         foreach ($config_dependencies as $dependency_type => $type_dependencies) {
           // Use associative array to avoid duplicates.
@@ -431,19 +429,27 @@ class ExtensionConfigHandler implements ExtensionConfigHandlerInterface {
         $config_dependencies = array();
       }
 
-      // Config provider is an implied module dependency.
-      $config_provider = substr($name, 0, strpos($name, '.'));
-      $config_dependencies['module'][$config_provider] = $config_provider;
+      // Config provider is an implied dependency. It can either be on core,
+      // which we do not need to list, a theme, or a module/profile (which are
+      // both treated as a 'module' dependency).
+      $config_provider = substr($config_name, 0, strpos($config_name, '.'));
+      if ($config_provider != 'core') {
+        $provider_type = $this->getExtensionType($config_provider, TRUE);
+        if ($provider_type !== 'theme') {
+          $provider_type = 'module';
+        }
+        $config_dependencies[$provider_type][$config_provider] = $config_provider;
+      }
 
-      $checked[$name] = $config_dependencies;
+      $checked[$config_name] = $config_dependencies;
     }
 
-    return $checked[$name];
+    return $checked[$config_name];
   }
 
 
   /**
-   * Suggest config to manage, based on currently managed config.
+   * Suggest config to manage, based on an extension's currently managed config.
    *
    * For the config listed in a projects .info.yml, find other config that is
    * dependant upon it, but which is not:
@@ -453,37 +459,35 @@ class ExtensionConfigHandler implements ExtensionConfigHandlerInterface {
    *
    * @param string $extension
    *   The machine name of the project to find suggested config for.
+   * @param int $recursion_limit
+   *   Optionally limit the levels of recursion.
+   *
    * @return array
    *   An array of config suggestions.
    */
   public function getExtensionConfigSuggestions($extension, $recursion_limit = NULL) {
     $dependants = array();
-    $listed_config = $this->getExtensionInfo($extension, 'managed');
-    $dependency_manager = \Drupal::service('config.manager')
-      ->getConfigDependencyManager();
-    foreach ($listed_config as $key) {
-      // Recursively fetch configuration entities that are dependent on this
-      // configuration entity (i.e. reverse dependencies).
-      $dependants += $this->getConfigSuggestions($key, $dependency_manager, $recursion_limit);
+    $listed_config = $this->getExtensionInfo($extension, 'managed', array());
+    if ($listed_config && is_array($listed_config)) {
+      $dependency_manager = $this->configManager->getConfigDependencyManager();
+      foreach ($listed_config as $config_name) {
+        // Recursively fetch configuration entities that are dependants of this
+        // configuration entity (i.e. reverse dependencies).
+        $dependants += $this->getConfigSuggestions($config_name, $dependency_manager, $recursion_limit);
+      }
     }
     return $this->sortAndFilterOutput(array('config' => $dependants));
   }
 
   /**
-   * @param $key
-   *   The config key to find the dependencies of.
-   * @param $dependency_manager
-   *
-   * @param null $recursion_limit
-   * @return mixed
+   * {@inheritdoc}
    */
-  public function getConfigSuggestions($key, $dependency_manager, $recursion_limit = NULL) {
+  public function getConfigSuggestions($config_name, ConfigDependencyManager $dependency_manager, $recursion_limit = NULL) {
     static $recursive_iterations = 0;
     static $checked = array();
 
-    if (!isset($checked[$key])) {
-      /** @var Drupal\Core\Config\Entity\ConfigDependencyManager $dependency_manager */
-      if ($dependants = array_keys($dependency_manager->getDependentEntities('config', $key))) {
+    if (!isset($checked[$config_name])) {
+      if ($dependants = array_keys($dependency_manager->getDependentEntities('config', $config_name))) {
         // Use associative array to avoid duplicates.
         $dependants = array_combine($dependants, $dependants);
 
@@ -499,38 +503,25 @@ class ExtensionConfigHandler implements ExtensionConfigHandlerInterface {
         $recursive_iterations--;
       }
 
-      $checked[$key] = $dependants;
+      $checked[$config_name] = $dependants;
     }
 
-    return $checked[$key];
+    return $checked[$config_name];
   }
 
   /**
    * {@inheritdoc}
    */
-  public function addToManagedConfig($extension, $config_keys) {
-
-  }
-
-
-  /**
-   * {@inheritdoc}
-   */
-  public function exportExtension($extension, $subdir = InstallStorage::CONFIG_INSTALL_DIRECTORY, $all = FALSE, $fully_normalize = FALSE) {
-    if ($extension_dirs = $this->getExtensionDirectories($extension)) {
-      return $this->exportExtensionDirectories($extension_dirs, $subdir, $all, $fully_normalize);
-    }
-    else {
-      return FALSE;
-    }
+  public function addToManagedConfig($extension, $config_names) {
+    // @TODO
   }
 
   /**
    * {@inheritdoc}
    */
-  public function exportAll($subdir = InstallStorage::CONFIG_INSTALL_DIRECTORY, $all = FALSE, $fully_normalize = FALSE) {
-    if ($extension_dirs = $this->getAllExtensionDirectories()) {
-      return $this->exportExtensionDirectories($extension_dirs, $subdir, $all, $fully_normalize);
+  public function export($subdir = InstallStorage::CONFIG_INSTALL_DIRECTORY, $force_unmanaged = FALSE, $fully_normalize = FALSE) {
+    if ($extension_dirs = $this->getExtensionDirectories()) {
+      return $this->exportExtensionDirectories($extension_dirs, $subdir, $force_unmanaged, $fully_normalize);
     }
     else {
       return FALSE;
@@ -544,12 +535,12 @@ class ExtensionConfigHandler implements ExtensionConfigHandlerInterface {
    *   Array of target directories as keys, mapped to their project names.
    * @param string $subdir
    *   The sub-directory of configuration to import.
-   * @param bool $all
+   * @param bool $force_unmanaged
    *   When set to FALSE, any config listed as 'unmanaged' is only exported
    *   when it has not previously been exported. Set to TRUE to overwrite any
    *   such config even if it has been previously exported.
    * @param bool $fully_normalize
-   *   Set to TRUE to sort configuration keys when exporting, and strip any
+   *   Set to TRUE to sort configuration names when exporting, and strip any
    *   empty arrays. This ensures more reliability when comparing between source
    *   and target config but usually means unnecessary changes.
    *
@@ -561,8 +552,9 @@ class ExtensionConfigHandler implements ExtensionConfigHandlerInterface {
    * @see drush_config_devel_get_config()
    * @see drush_config_devel_process_config()
    */
-  protected function exportExtensionDirectories($extension_dirs, $subdir, $all, $fully_normalize) {
+  protected function exportExtensionDirectories($extension_dirs, $subdir, $force_unmanaged, $fully_normalize) {
     $errors = [];
+    $config_factory = $this->configManager->getConfigFactory();
 
     foreach ($extension_dirs as $source_dir => $extension_name) {
       // Determine the type of extension we're dealing with.
@@ -583,13 +575,13 @@ class ExtensionConfigHandler implements ExtensionConfigHandlerInterface {
           try {
             $source_dir_storage = new FileStorage($source_dir . '/' . $subdir);
             foreach ($info as $name) {
-              $config = \Drupal::config($name);
+              $config = $config_factory->get($name);
               if ($data = $config->get()) {
                 $existing_export = $source_dir_storage->read($name);
 
                 // Skip existing config that is listed as 'unmanaged' unless the
-                // 'all' option was passed.
-                if ($existing_export && isset($unmanaged[$name]) && !$all) {
+                // 'force unmanaged' option was passed.
+                if ($existing_export && isset($unmanaged[$name]) && !$force_unmanaged) {
                   continue;
                 }
 
@@ -673,7 +665,7 @@ class ExtensionConfigHandler implements ExtensionConfigHandlerInterface {
       // system_rebuild_module_data() and
       // \Drupal\Core\Extension\ThemeHandlerInterface::rebuildThemeData().
       foreach (['module', 'theme'] as $candidate) {
-        if (\Drupal::state()->get('system.' . $candidate . '.files', array())) {
+        if ($this->state->get('system.' . $candidate . '.files', array())) {
           $type = $candidate;
           break;
         }
@@ -686,7 +678,7 @@ class ExtensionConfigHandler implements ExtensionConfigHandlerInterface {
   /**
    * {@inheritdoc}
    */
-  public static function normalizeConfig($name, $config, $sort_and_filter = TRUE, $ignore = array('uuid', '_core')) {
+  public static function normalizeConfig($config_name, $config, $sort_and_filter = TRUE, $ignore = array('uuid', '_core')) {
     // Remove "ignore" elements.
     foreach ($ignore as $element) {
       unset($config[$element]);
@@ -698,11 +690,11 @@ class ExtensionConfigHandler implements ExtensionConfigHandlerInterface {
         // Image style effects are a special case, since they have to use UUIDs
         // as their keys, so remove that from the ignore list. Remove this once
         // core issue https://www.drupal.org/node/2247257 is fixed.
-        if (isset($value['uuid']) && $value['uuid'] === $key && in_array('uuid', $ignore) && preg_match('#^image\.style\.[^.]+\.effects#', $name)) {
-          $new = static::normalizeConfig($name . '.' . $key, $value, $sort_and_filter, array_diff($ignore, array('uuid')));
+        if (isset($value['uuid']) && $value['uuid'] === $key && in_array('uuid', $ignore) && preg_match('#^image\.style\.[^.]+\.effects#', $config_name)) {
+          $new = static::normalizeConfig($config_name . '.' . $key, $value, $sort_and_filter, array_diff($ignore, array('uuid')));
         }
         else {
-          $new = static::normalizeConfig($name . '.' . $key, $value, $sort_and_filter, $ignore);
+          $new = static::normalizeConfig($config_name . '.' . $key, $value, $sort_and_filter, $ignore);
         }
 
         if (count($new)) {

--- a/src/ExtensionConfigHandler.php
+++ b/src/ExtensionConfigHandler.php
@@ -371,7 +371,7 @@ class ExtensionConfigHandler implements ExtensionConfigHandlerInterface {
   /**
    * {@inheritdoc}
    */
-  public function getConfigDependencies($extension, $limit = NULL) {
+  public function getExtensionConfigDependencies($extension, $limit = NULL) {
     $dependencies = array();
     $listed_config = $this->getExtensionInfo($extension, 'managed');
     foreach ($listed_config as $key) {
@@ -443,9 +443,20 @@ class ExtensionConfigHandler implements ExtensionConfigHandlerInterface {
 
 
   /**
-   * {@inheritdoc}
+   * Suggest config to manage, based on currently managed config.
+   *
+   * For the config listed in a projects .info.yml, find other config that is
+   * dependant upon it, but which is not:
+   *  - Itself a dependency of the config listed in cm_config_tools.managed
+   *  - Already included explicitly in cm_config_tools.managed
+   *  - Explicitly ignored in the cm_config_tools.unmanaged
+   *
+   * @param string $extension
+   *   The machine name of the project to find suggested config for.
+   * @return array
+   *   An array of config suggestions.
    */
-  public function getDependentConfigSuggestions($extension, $recursion_limit = NULL) {
+  public function getExtensionConfigSuggestions($extension, $recursion_limit = NULL) {
     $dependants = array();
     $listed_config = $this->getExtensionInfo($extension, 'managed');
     $dependency_manager = \Drupal::service('config.manager')

--- a/src/ExtensionConfigHandler.php
+++ b/src/ExtensionConfigHandler.php
@@ -375,7 +375,7 @@ class ExtensionConfigHandler implements ExtensionConfigHandlerInterface {
     $dependencies = array();
     $listed_config = $this->getExtensionInfo($extension, 'managed');
     foreach ($listed_config as $key) {
-      $config_dependencies = $this->getIndividualConfigDependencies($key, $limit);
+      $config_dependencies = $this->getConfigDependencies($key, $limit);
       foreach ($config_dependencies as $dependency_type => $type_dependencies) {
         if (!isset($dependencies[$dependency_type])) {
           $dependencies[$dependency_type] = array();
@@ -396,7 +396,7 @@ class ExtensionConfigHandler implements ExtensionConfigHandlerInterface {
    *   Optionally limit the levels of recursion.
    * @return mixed
    */
-  public function getIndividualConfigDependencies($name, $recursion_limit = NULL) {
+  public function getConfigDependencies($name, $recursion_limit = NULL) {
     static $recursive_iterations = 0;
     static $checked = array();
 
@@ -464,7 +464,7 @@ class ExtensionConfigHandler implements ExtensionConfigHandlerInterface {
     foreach ($listed_config as $key) {
       // Recursively fetch configuration entities that are dependent on this
       // configuration entity (i.e. reverse dependencies).
-      $dependants += $this->getIndividualConfigDependants($key, $dependency_manager, $recursion_limit);
+      $dependants += $this->getConfigSuggestions($key, $dependency_manager, $recursion_limit);
     }
     return $this->sortAndFilterOutput(array('config' => $dependants));
   }
@@ -477,7 +477,7 @@ class ExtensionConfigHandler implements ExtensionConfigHandlerInterface {
    * @param null $recursion_limit
    * @return mixed
    */
-  public function getIndividualConfigDependants($key, $dependency_manager, $recursion_limit = NULL) {
+  public function getConfigSuggestions($key, $dependency_manager, $recursion_limit = NULL) {
     static $recursive_iterations = 0;
     static $checked = array();
 
@@ -491,7 +491,7 @@ class ExtensionConfigHandler implements ExtensionConfigHandlerInterface {
         if ($recursion_limit && $recursive_iterations < $recursion_limit) {
           $base_dependants = $dependants;
           foreach ($base_dependants as $dependant) {
-            if ($sub_dependants = $this->getIndividualConfigDependants($dependant, $dependency_manager, $recursion_limit)) {
+            if ($sub_dependants = $this->getConfigSuggestions($dependant, $dependency_manager, $recursion_limit)) {
               $dependants += $sub_dependants;
             }
           }

--- a/src/ExtensionConfigHandler.php
+++ b/src/ExtensionConfigHandler.php
@@ -371,11 +371,11 @@ class ExtensionConfigHandler implements ExtensionConfigHandlerInterface {
   /**
    * {@inheritdoc}
    */
-  public function getConfigDependancies($extension, $limit = NULL) {
+  public function getConfigDependencies($extension, $limit = NULL) {
     $dependencies = array();
     $listed_config = $this->getExtensionInfo($extension, 'managed');
     foreach ($listed_config as $key) {
-      $config_dependencies = $this->getIndividualConfigDependancies($key, $limit);
+      $config_dependencies = $this->getIndividualConfigDependencies($key, $limit);
       foreach ($config_dependencies as $dependency_type => $type_dependencies) {
         if (!isset($dependencies[$dependency_type])) {
           $dependencies[$dependency_type] = array();
@@ -396,7 +396,7 @@ class ExtensionConfigHandler implements ExtensionConfigHandlerInterface {
    *   Optionally limit the levels of recursion.
    * @return mixed
    */
-  public function getIndividualConfigDependancies($name, $recursion_limit = NULL) {
+  public function getIndividualConfigDependencies($name, $recursion_limit = NULL) {
     static $recursive_iterations = 0;
     static $checked = array();
 
@@ -413,7 +413,7 @@ class ExtensionConfigHandler implements ExtensionConfigHandlerInterface {
           $recursive_iterations++;
           if ($recursion_limit && $recursive_iterations < $recursion_limit) {
             foreach ($config_dependencies['config'] as $dependency) {
-              $sub_dependencies = $this->getIndividualConfigDependancies($dependency, $recursion_limit);
+              $sub_dependencies = $this->getIndividualConfigDependencies($dependency, $recursion_limit);
 
               // Add this dependency's dependencies to the list to be returned.
               foreach ($sub_dependencies as $dependency_type => $type_dependencies) {
@@ -460,7 +460,7 @@ class ExtensionConfigHandler implements ExtensionConfigHandlerInterface {
 
   /**
    * @param $key
-   *   The config key to find the dependancies of.
+   *   The config key to find the dependencies of.
    * @param $dependency_manager
    *
    * @param null $recursion_limit

--- a/src/ExtensionConfigHandler.php
+++ b/src/ExtensionConfigHandler.php
@@ -508,7 +508,7 @@ class ExtensionConfigHandler implements ExtensionConfigHandlerInterface {
   /**
    * {@inheritdoc}
    */
-  public function addConfigKeysToManifest($extension, $config_keys) {
+  public function addToManagedConfig($extension, $config_keys) {
 
   }
 

--- a/src/ExtensionConfigHandlerInterface.php
+++ b/src/ExtensionConfigHandlerInterface.php
@@ -125,9 +125,9 @@ interface ExtensionConfigHandlerInterface {
    *
    * For the config listed in a projects .info.yml, find other config that is
    * dependant upon it, but which is not:
-   *  - Itself a dependency of the config listed in cm_config_tools.export
-   *  - Already included explicitly in cm_config_tools.export
-   *  - Explicitly ignored in the cm_config_tools.ignore
+   *  - Itself a dependency of the config listed in cm_config_tools.managed
+   *  - Already included explicitly in cm_config_tools.managed
+   *  - Explicitly ignored in the cm_config_tools.unmanaged
    *
    * @param string $extension
    *   The machine name of the project to find dependant config for.
@@ -137,10 +137,10 @@ interface ExtensionConfigHandlerInterface {
   public function getDependentConfigSuggestions($extension);
 
   /**
-   * Adds the provided config keys to an extensions explicitly exported config.
+   * Adds the provided config keys to an extensions managed config.
    *
    * Add the config keys to an extensions .info.yml, under
-   * cm_config_tools.export
+   * cm_config_tools.managed
    *
    * @param $extension
    * @param $config_keys

--- a/src/ExtensionConfigHandlerInterface.php
+++ b/src/ExtensionConfigHandlerInterface.php
@@ -32,6 +32,7 @@ interface ExtensionConfigHandlerInterface {
    */
   public function importExtension($extension, $subdir = InstallStorage::CONFIG_INSTALL_DIRECTORY);
 
+
   /**
    * Import configuration from all extensions for this workflow.
    *
@@ -105,6 +106,47 @@ interface ExtensionConfigHandlerInterface {
    *   TRUE if the operation succeeded.
    */
   public function importFromComparer(StorageComparerInterface $storage_comparer);
+
+  /**
+   * Get the config dependancies for an extension.
+   *
+   * For the config currently exported to a project, find the config
+   * dependencies required for it to work.
+   *
+   * @param string $extension
+   *   The machine name of the project to get the config dependencies for.
+   * @return array
+   *   An array of config the extension depends on.
+   */
+  public function getConfigDependancies($extension);
+
+  /**
+   * Suggest config dependants to export.
+   *
+   * For the config listed in a projects .info.yml, find other config that is
+   * dependant upon it, but which is not:
+   *  - Itself a dependency of the config listed in cm_config_tools.export
+   *  - Already included explicitly in cm_config_tools.export
+   *  - Explicitly ignored in the cm_config_tools.ignore
+   *
+   * @param string $extension
+   *   The machine name of the project to find dependant config for.
+   * @return array
+   *   An array of config that depends on config currently exported.
+   */
+  public function getDependentConfigSuggestions($extension);
+
+  /**
+   * Adds the provided config keys to an extensions explicitly exported config.
+   *
+   * Add the config keys to an extensions .info.yml, under
+   * cm_config_tools.export
+   *
+   * @param $extension
+   * @param $config_keys
+   * @return mixed
+   */
+  public function addConfigKeysToManifest($extension, $config_keys);
 
   /**
    * Export configuration to extensions.

--- a/src/ExtensionConfigHandlerInterface.php
+++ b/src/ExtensionConfigHandlerInterface.php
@@ -131,7 +131,7 @@ interface ExtensionConfigHandlerInterface {
   public function getExtensionConfigSuggestions($extension);
 
   /**
-   * Adds the provided config keys to an extensions managed config.
+   * Adds the provided config to an extensions managed config.
    *
    * Add the config keys to an extensions .info.yml, under
    * cm_config_tools.managed
@@ -140,7 +140,7 @@ interface ExtensionConfigHandlerInterface {
    * @param $config_keys
    * @return mixed
    */
-  public function addConfigKeysToManifest($extension, $config_keys);
+  public function addToManagedConfig($extension, $config_keys);
 
   /**
    * Export configuration to extensions.

--- a/src/ExtensionConfigHandlerInterface.php
+++ b/src/ExtensionConfigHandlerInterface.php
@@ -179,6 +179,11 @@ interface ExtensionConfigHandlerInterface {
    * @return array|bool
    *   Array of any errors, keyed by extension names, FALSE if configuration
    *   changes could not be found to import, or TRUE on successful export.
+   *
+   * @TODO Optionally (but by default) export dependencies, and suggest config
+   * dependants to export to (allowing opt-out of getting suggestions, and if
+   * possible allowing opt-in to export all dependants).
+   * @TODO Support 'implicit' exporting of dependants.
    */
   public function export($subdir = InstallStorage::CONFIG_INSTALL_DIRECTORY, $force_unmanaged = FALSE, $fully_normalize = FALSE);
 

--- a/src/ExtensionConfigHandlerInterface.php
+++ b/src/ExtensionConfigHandlerInterface.php
@@ -176,7 +176,7 @@ interface ExtensionConfigHandlerInterface {
    *   If $key was not specified, just return TRUE or FALSE, depending on
    *   whether there is any cm_config_tools info for the extension at all.
    */
-  public function getExtensionInfo($extension_name, $key = NULL, $default = NULL, $parent = 'cm_config_tools', $disabled = FALSE);
+  public function getExtensionInfo($extension_name, $key = NULL, $default = NULL, $disabled = FALSE);
 
   /**
    * Gets the type for the given extension.

--- a/src/ExtensionConfigHandlerInterface.php
+++ b/src/ExtensionConfigHandlerInterface.php
@@ -7,6 +7,7 @@
 
 namespace Drupal\cm_config_tools;
 
+use Drupal\Core\Config\Entity\ConfigDependencyManager;
 use Drupal\Core\Config\InstallStorage;
 use Drupal\Core\Config\StorageComparerInterface;
 
@@ -14,24 +15,6 @@ use Drupal\Core\Config\StorageComparerInterface;
  * Defines a class to help with importing and exporting config from extensions.
  */
 interface ExtensionConfigHandlerInterface {
-
-  /**
-   * Import configuration from extensions.
-   *
-   * @param string|array $extension
-   *   The machine name of the project to import configuration from. Multiple
-   *   projects can be specified, separated with commas, or as an array.
-   * @param string $subdir
-   *   The sub-directory of configuration to import. Defaults to
-   *   "config/install".
-   *
-   * @return bool
-   *   TRUE if the operation succeeded; FALSE if the configuration changes could
-   *   not be found to import. May also throw exceptions if there is a problem
-   *   during saving the configuration.
-   */
-  public function importExtension($extension, $subdir = InstallStorage::CONFIG_INSTALL_DIRECTORY);
-
 
   /**
    * Import configuration from all extensions for this workflow.
@@ -42,26 +25,17 @@ interface ExtensionConfigHandlerInterface {
    * @param string $subdir
    *   The sub-directory of configuration to import. Defaults to
    *   "config/install".
+   * @param bool $force_unmanaged
+   *   Optional. Without this option, any config listed as 'unmanaged' is only
+   *   considered when it has not previously been created. Set this option to
+   *   overwrite any such config even if it has been previously created.
    *
    * @return bool
    *   TRUE if the operation succeeded; FALSE if the configuration changes could
    *   not be found to import. May also throw exceptions if there is a problem
    *   during saving the configuration.
    */
-  public function importAll($subdir = InstallStorage::CONFIG_INSTALL_DIRECTORY);
-
-  /**
-   * Get directories of supplied extensions.
-   *
-   * @param string|array $extension
-   *   The machine name of the project to import configuration from. Multiple
-   *   projects can be specified, separated with commas, or as an array.
-   *
-   * @return array
-   *   Array of directories of extensions to import from, mapped to their
-   *   project names.
-   */
-  public function getExtensionDirectories($extension);
+  public function import($subdir = InstallStorage::CONFIG_INSTALL_DIRECTORY, $force_unmanaged = FALSE);
 
   /**
    * Get directories of all extensions that have a 'cm_config_tools' key.
@@ -69,11 +43,14 @@ interface ExtensionConfigHandlerInterface {
    * Configuration should be imported from any enabled projects that contain a
    * 'cm_config_tools' key in their .info.yml files (even if it is empty).
    *
+   * @TODO Do we need somewhere to warn of unsupported behaviour if multipe
+   * extensions with the cm_config_tools key are found?
+   *
    * @return array
    *   Array of directories of extensions to import from, mapped to their
    *   project names.
    */
-  public function getAllExtensionDirectories();
+  public function getExtensionDirectories();
 
   /**
    * Get the config storage comparer that will be used for importing.
@@ -89,12 +66,16 @@ interface ExtensionConfigHandlerInterface {
    * @param string $subdir
    *   The sub-directory of configuration to import. Defaults to
    *   "config/install".
+   * @param bool $force_unmanaged
+   *   Optional. Without this option, any config listed as 'unmanaged' is only
+   *   considered when it has not previously been created. Set this option to
+   *   overwrite any such config even if it has been previously created.
    *
    * @return bool|ConfigDiffStorageComparer
    *   The storage comparer; FALSE if configuration changes could not be found
    *   to import.
    */
-  public function getStorageComparer(array $source_dirs, $subdir = InstallStorage::CONFIG_INSTALL_DIRECTORY);
+  public function getStorageComparer(array $source_dirs, $subdir = InstallStorage::CONFIG_INSTALL_DIRECTORY, $force_unmanaged = FALSE);
 
   /**
    * Perform import of configuration from the supplied comparer.
@@ -115,56 +96,67 @@ interface ExtensionConfigHandlerInterface {
    *
    * @param string $extension
    *   The machine name of the project to get the config dependencies for.
+   *
    * @return array
-   *   An array of config the extension depends on.
+   *   An array of things the extension depends on, keyed by dependency type.
    */
   public function getExtensionConfigDependencies($extension);
+
+  /**
+   * Get the dependencies for a single config item.
+   *
+   * @param string $config_name
+   *   The config name to find the dependencies of.
+   * @param int $recursion_limit
+   *   Optionally limit the levels of recursion.
+   *
+   * @return array
+   *   An array of the config's dependencies, keyed by dependency type.
+   */
+  public function getConfigDependencies($config_name, $recursion_limit = NULL);
 
   /**
    * Suggest config to manage, based on currently managed config.
    *
    * @param string $extension
    *   The machine name of the project to find suggested config for.
+   * @param int $recursion_limit
+   *   Optional recursion limit.
+   *
    * @return array
    *   An array of config suggestions.
    */
-  public function getExtensionConfigSuggestions($extension);
+  public function getExtensionConfigSuggestions($extension, $recursion_limit = NULL);
 
   /**
-   * Adds the provided config to an extensions managed config.
+   * Suggest config to manage, based on a config item.
    *
-   * Add the config keys to an extensions .info.yml, under
-   * cm_config_tools.managed
+   * @param string $config_name
+   *   The config entity name to find the dependencies of.
+   * @param \Drupal\Core\Config\Entity\ConfigDependencyManager $dependency_manager
+   *   Dependency manager class.
+   * @param int $recursion_limit
+   *   Optionally limit the levels of recursion.
    *
-   * @param $extension
-   * @param $config_keys
-   * @return mixed
+   * @return array
+   *   Associative array of config names.
    */
-  public function addToManagedConfig($extension, $config_keys);
+  public function getConfigSuggestions($config_name, ConfigDependencyManager $dependency_manager, $recursion_limit = NULL);
 
   /**
-   * Export configuration to extensions.
+   * Adds the provided config to an extension's managed config.
    *
-   * @param string|array $extension
-   *   The machine name of the project to export configuration to. Multiple
-   *   projects can be specified, separated with commas, or as an array.
-   * @param string $subdir
-   *   The sub-directory of configuration to import. Defaults to
-   *   "config/install".
-   * @param bool $all
-   *   Optional. Without this option, any config listed as 'unmanaged' is only
-   *   exported when it has not previously been exported. Set this option to
-   *   overwrite any such config even if it has been previously exported.
-   * @param bool $fully_normalize
-   *   Optional. Sort configuration keys when exporting, and strip any empty
-   *   arrays. This ensures more reliability when comparing between source and
-   *   target config but usually means unnecessary changes.
+   * Add the config names to an extension's .info.yml, under
+   * cm_config_tools.managed.
    *
-   * @return array|bool
-   *   Array of any errors, keyed by extension names, FALSE if configuration
-   *   changes could not be found to import, or TRUE on successful export.
+   * @param string $extension
+   *   Extemson name to export to.
+   * @param array $config_names
+   *
+   * @return bool
+   *   Returns TRUE when successful.
    */
-  public function exportExtension($extension, $subdir = InstallStorage::CONFIG_INSTALL_DIRECTORY, $all = FALSE, $fully_normalize = FALSE);
+  public function addToManagedConfig($extension, $config_names);
 
   /**
    * Export configuration to all extensions using this workflow.
@@ -175,12 +167,12 @@ interface ExtensionConfigHandlerInterface {
    * @param string $subdir
    *   The sub-directory of configuration to import. Defaults to
    *   "config/install".
-   * @param bool $all
+   * @param bool $force_unmanaged
    *   Optional. Without this option, any config listed as 'unmanaged' is only
    *   exported when it has not previously been exported. Set this option to
    *   overwrite any such config even if it has been previously exported.
    * @param bool $fully_normalize
-   *   Optional. Sort configuration keys when exporting, and strip any empty
+   *   Optional. Sort keys within configuration exports, and strip any empty
    *   arrays. This ensures more reliability when comparing between source and
    *   target config but usually means unnecessary changes.
    *
@@ -188,7 +180,7 @@ interface ExtensionConfigHandlerInterface {
    *   Array of any errors, keyed by extension names, FALSE if configuration
    *   changes could not be found to import, or TRUE on successful export.
    */
-  public function exportAll($subdir = InstallStorage::CONFIG_INSTALL_DIRECTORY, $all = FALSE, $fully_normalize = FALSE);
+  public function export($subdir = InstallStorage::CONFIG_INSTALL_DIRECTORY, $force_unmanaged = FALSE, $fully_normalize = FALSE);
 
   /**
    * Get cm_config_tools info from extension's .info.yml file.
@@ -201,10 +193,6 @@ interface ExtensionConfigHandlerInterface {
    * @param mixed $default
    *   The default value to return when $key is specified and there is no value
    *   for it. Has no effect if $key is not specified.
-   * @param string $parent
-   *   Defaults to cm_config_tools, but specify to get a key within a different
-   *   parent key in the .info.yml file. Specify as NULL to get a root key's
-   *   values.
    * @param bool $disabled
    *   Optionally check for disabled modules and themes too.
    *
@@ -236,7 +224,7 @@ interface ExtensionConfigHandlerInterface {
    * isn't really worth it, especially as a couple of extra parameters can be
    * introduced here to behave differently for certain situations.
    *
-   * @param string $name
+   * @param string $config_name
    *   Configuration item name.
    * @param array $config
    *   Configuration array to normalize.
@@ -251,6 +239,6 @@ interface ExtensionConfigHandlerInterface {
    *
    * @see \Drupal\config_update\ConfigDiffer::normalize()
    */
-  public static function normalizeConfig($name, $config, $sort_and_filter = TRUE, $ignore = array('uuid', '_core'));
+  public static function normalizeConfig($config_name, $config, $sort_and_filter = TRUE, $ignore = array('uuid', '_core'));
 
 }

--- a/src/ExtensionConfigHandlerInterface.php
+++ b/src/ExtensionConfigHandlerInterface.php
@@ -108,7 +108,7 @@ interface ExtensionConfigHandlerInterface {
   public function importFromComparer(StorageComparerInterface $storage_comparer);
 
   /**
-   * Get the config dependancies for an extension.
+   * Get the config dependencies for an extension.
    *
    * For the config currently exported to a project, find the config
    * dependencies required for it to work.
@@ -118,7 +118,7 @@ interface ExtensionConfigHandlerInterface {
    * @return array
    *   An array of config the extension depends on.
    */
-  public function getConfigDependancies($extension);
+  public function getConfigDependencies($extension);
 
   /**
    * Suggest config dependants to export.

--- a/src/ExtensionConfigHandlerInterface.php
+++ b/src/ExtensionConfigHandlerInterface.php
@@ -116,7 +116,7 @@ interface ExtensionConfigHandlerInterface {
    *   The sub-directory of configuration to import. Defaults to
    *   "config/install".
    * @param bool $all
-   *   Optional. Without this option, any config listed as 'create_only' is only
+   *   Optional. Without this option, any config listed as 'unmanaged' is only
    *   exported when it has not previously been exported. Set this option to
    *   overwrite any such config even if it has been previously exported.
    * @param bool $fully_normalize
@@ -140,7 +140,7 @@ interface ExtensionConfigHandlerInterface {
    *   The sub-directory of configuration to import. Defaults to
    *   "config/install".
    * @param bool $all
-   *   Optional. Without this option, any config listed as 'create_only' is only
+   *   Optional. Without this option, any config listed as 'unmanaged' is only
    *   exported when it has not previously been exported. Set this option to
    *   overwrite any such config even if it has been previously exported.
    * @param bool $fully_normalize

--- a/src/ExtensionConfigHandlerInterface.php
+++ b/src/ExtensionConfigHandlerInterface.php
@@ -118,23 +118,17 @@ interface ExtensionConfigHandlerInterface {
    * @return array
    *   An array of config the extension depends on.
    */
-  public function getConfigDependencies($extension);
+  public function getExtensionConfigDependencies($extension);
 
   /**
-   * Suggest config dependants to export.
-   *
-   * For the config listed in a projects .info.yml, find other config that is
-   * dependant upon it, but which is not:
-   *  - Itself a dependency of the config listed in cm_config_tools.managed
-   *  - Already included explicitly in cm_config_tools.managed
-   *  - Explicitly ignored in the cm_config_tools.unmanaged
+   * Suggest config to manage, based on currently managed config.
    *
    * @param string $extension
-   *   The machine name of the project to find dependant config for.
+   *   The machine name of the project to find suggested config for.
    * @return array
-   *   An array of config that depends on config currently exported.
+   *   An array of config suggestions.
    */
-  public function getDependentConfigSuggestions($extension);
+  public function getExtensionConfigSuggestions($extension);
 
   /**
    * Adds the provided config keys to an extensions managed config.

--- a/src/StorageReplaceDataMappedWrapper.php
+++ b/src/StorageReplaceDataMappedWrapper.php
@@ -34,7 +34,7 @@ class StorageReplaceDataMappedWrapper extends StorageReplaceDataWrapper {
   /**
    * Maps configuration name to the supplied source name.
    *
-   * @param $name
+   * @param string $name
    *   The configuration object name to map.
    * @param string $source
    *   The source of the data.
@@ -49,7 +49,7 @@ class StorageReplaceDataMappedWrapper extends StorageReplaceDataWrapper {
   /**
    * Gets the mapped source name for the supplied configuration name.
    *
-   * @param $name
+   * @param string $name
    *   The configuration object name.
    *
    * @return string|null


### PR DESCRIPTION
Magic!
- Rename the keys we use in the 'manifest' (info file) (and update related code accordingly - see https://www.drupal.org/node/2806197 although that is outside the scope of the MVP)
- Suggest dependants to export, with ability to export them at the same time (by explicitly adding them to the manifest for now)
- Always export dependencies of whatever is being explicitly exported
