### PR TITLE
PHP warnings around inexistent modules

### DIFF
--- a/src/ExtensionConfigHandler.php
+++ b/src/ExtensionConfigHandler.php
@@ -960,7 +960,9 @@ class ExtensionConfigHandler implements ExtensionConfigHandlerInterface {
                   // already depend on each other anyway.
                   $minimised = $missing_dependencies;
                   foreach ($missing_dependencies as $missing_dependency) {
-                    $minimised = array_diff($minimised, array_keys($module_data[$missing_dependency]->requires));
+                    if (isset($module_data[$missing_dependency])) {
+                      $minimised = array_diff($minimised, array_keys($module_data[$missing_dependency]->requires));
+                    }
                   }
 
                   $info_filename = $module_data[$extension_name]->getPathname();


### PR DESCRIPTION
During a `drush cmce`:

```bash
array_keys() expects parameter 1 to be array, null given ExtensionConfigHandler.php:963                                                                         [warning]
array_diff(): Argument #2 is not an array ExtensionConfigHandler.php:963                                                                                        [warning]
```

These are due to an inexistent module being referenced by config, so within the troublesome line, `$module_data[$missing_dependency]` will not exist. The line is only about minimising the list of dependencies, so just avoid running the line as the missing dependency (and any of its dependencies) should be retained in what is about to be exported.